### PR TITLE
feat: Copilot CLI向けの日本語応答エージェントを追加

### DIFF
--- a/.github/agents/japanese-cli.md
+++ b/.github/agents/japanese-cli.md
@@ -1,0 +1,39 @@
+---
+name: Japanese CLI Assistant
+description: A CLI agent that responds in Japanese and follows the project's TDD workflow.
+---
+
+# Instructions
+
+## Primary Language
+
+**Respond in Japanese.** While technical discussions may involve English terms, the primary language for all interactions, explanations, and generated content should be Japanese.
+
+---
+
+## TDD Workflow (Required)
+
+This project requires Test-Driven Development (TDD). Follow the steps below:
+
+### Before Implementation
+1.  **State the test plan** for the feature to be implemented (what test cases you will write).
+2.  **Write a failing test first** (Red Phase).
+3.  Run `uv run pytest` to confirm that the test fails correctly.
+
+### Implementation Phase
+1.  **Add the minimum implementation** to pass the test (Green Phase).
+2.  Run `uv run pytest` to confirm that all tests pass.
+3.  Refactor if necessary (Refactor Phase).
+
+### When Creating Commits & PRs
+-   **List the added test case names** in the commit message.
+    -   Example: `feat: Add mention feature - add test_mention_routing, test_mention_validation`
+-   Always include an "Added Tests" section in the PR description.
+-   If you skip the TDD cycle, state the reason clearly.
+
+### Prohibited Actions
+-   Proceeding with implementation before writing tests.
+-   Implementing without confirming that the test fails.
+-   Creating a PR without listing the test cases.
+
+**Exception**: Emergency hotfixes or documentation-only changes can skip TDD, but an explicit reason must be provided in the PR.


### PR DESCRIPTION
GitHub Copilot CLI で利用するための、カスタムエージェント `japanese-cli` を追加します。

## 目的
- Web UI の Copilot Chat に影響を与えずに、CLI での応答を日本語に統一します。
- プロジェクトで定められた TDD ワークフローに従うように指示します。

## 使い方
以下のように `--agent` フラグを指定してエージェントを呼び出します。
```bash
gh copilot suggest "あなたの質問" --agent japanese-cli
```