### PR TITLE
fix: Correct path resolution in hooks/install.sh

### DIFF
--- a/hooks/install.sh
+++ b/hooks/install.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Install Git hooks from the hooks/ directory
 
-HOOKS_DIR="$(dirname "$0")/hooks"
+HOOKS_DIR="$(dirname "$0")"
 GIT_HOOKS_DIR=".git/hooks"
 
 echo "Installing Git hooks..."


### PR DESCRIPTION
## 問題
`hooks/install.sh`のパス解決が誤っており、スクリプトからフックファイルを見つけられませんでした。

## 修正内容
`HOOKS_DIR`の定義を修正:
- 修正前: `HOOKS_DIR="$(dirname "$0")/hooks"` （hooks/hooks/を参照）
- 修正後: `HOOKS_DIR="$(dirname "$0")"` （hooks/を参照）

## 検証
```bash
$ sh hooks/install.sh
Installing Git hooks...
✅ Installed pre-commit hook
✅ Installed pre-push hook
✨ Git hooks installation complete!
```

フックファイルが正しく`.git/hooks/`にコピーされることを確認しました。