### PR TITLE
feat: Remove  from Gemini inputSchema

### DIFF
--- a/src/multi_llm_chat/providers/gemini.py
+++ b/src/multi_llm_chat/providers/gemini.py
@@ -49,6 +49,10 @@ def mcp_tools_to_gemini_format(mcp_tools: List[Dict[str, Any]]) -> Optional[List
             )
             continue
 
+        # Remove $schema field that Gemini doesn't accept
+        if parameters and isinstance(parameters, dict):
+            parameters = {k: v for k, v in parameters.items() if k != "$schema"}
+
         func_decl = FunctionDeclaration(
             name=name,
             description=description,


### PR DESCRIPTION
- 変更点:  フィールドを削除する。\n- 目的: Gemini API でエラーになるのを防止。\n- テスト追加: test_mcp_tools_schema_field_is_removed を追加。