### PR TITLE
feat: 会話更新イベントでautosave更新を実装

### DIFF
--- a/src/multi_llm_chat/chat_service.py
+++ b/src/multi_llm_chat/chat_service.py
@@ -350,9 +350,7 @@ class ChatService:
             resolved_store = HistoryStore()
 
         resolved_interval = (
-            self._autosave_min_interval_sec
-            if min_interval_sec is None
-            else min_interval_sec
+            self._autosave_min_interval_sec if min_interval_sec is None else min_interval_sec
         )
 
         if (

--- a/src/multi_llm_chat/history.py
+++ b/src/multi_llm_chat/history.py
@@ -103,10 +103,10 @@ class HistoryStore:
     def history_exists(self, user_id: str, display_name: str) -> bool:
         """Check if a history file already exists."""
         try:
-            self.load_history(user_id, display_name)
-            return True
-        except (FileNotFoundError, ValueError):
+            path = self._history_path(user_id, display_name)
+        except ValueError:
             return False
+        return path.exists()
 
     def has_autosave(self, user_id: str) -> bool:
         """Check if an autosave draft file exists for a user."""

--- a/src/multi_llm_chat/history.py
+++ b/src/multi_llm_chat/history.py
@@ -102,7 +102,11 @@ class HistoryStore:
 
     def history_exists(self, user_id: str, display_name: str) -> bool:
         """Check if a history file already exists."""
-        return self._history_path(user_id, display_name).exists()
+        try:
+            self.load_history(user_id, display_name)
+            return True
+        except (FileNotFoundError, ValueError):
+            return False
 
     def has_autosave(self, user_id: str) -> bool:
         """Check if an autosave draft file exists for a user."""
@@ -119,6 +123,8 @@ class HistoryStore:
             try:
                 data = json.loads(path.read_text())
             except (json.JSONDecodeError, OSError):
+                continue
+            if data.get("type") == AUTOSAVE_TYPE:
                 continue
             name = data.get("display_name")
             if name:
@@ -186,11 +192,16 @@ class HistoryStore:
         if not user_dir.exists():
             raise FileNotFoundError("User directory not found")
 
-        target_sanitized = _sanitize_display_name(display_name)
+        target_sanitized = sanitize_name(display_name)
+        if target_sanitized != AUTOSAVE_RESERVED_NAME:
+            target_sanitized = _sanitize_display_name(display_name)
         for path in user_dir.glob("*.json"):
             try:
                 data = json.loads(path.read_text())
             except (json.JSONDecodeError, OSError):
+                continue
+
+            if data.get("type") == AUTOSAVE_TYPE:
                 continue
 
             if data.get("display_name") == display_name or path.stem == target_sanitized:

--- a/src/multi_llm_chat/webui/handlers.py
+++ b/src/multi_llm_chat/webui/handlers.py
@@ -265,7 +265,10 @@ async def respond(
     # Initialize or reuse ChatService (session-scoped for provider reuse)
     # Reset service if history was cleared (e.g., new chat action)
     if chat_service is None or not logic_history:
+        if chat_service is not None and not logic_history:
+            chat_service.configure_autosave(user_id=None)
         chat_service = ChatService()
+    chat_service.configure_autosave(user_id=user_id)
 
     # Update service state with current histories and system prompt
     chat_service.display_history = display_history

--- a/tests/test_chat_service.py
+++ b/tests/test_chat_service.py
@@ -812,10 +812,14 @@ class TestChatServiceAutosave:
         service.request_autosave()
         timers = []
 
-        with patch(
-            "multi_llm_chat.chat_service.asyncio.get_running_loop",
-            side_effect=RuntimeError("no running event loop"),
-        ), patch("multi_llm_chat.chat_service.threading.Timer") as mock_timer:
+        with (
+            patch(
+                "multi_llm_chat.chat_service.asyncio.get_running_loop",
+                side_effect=RuntimeError("no running event loop"),
+            ),
+            patch("multi_llm_chat.chat_service.threading.Timer") as mock_timer,
+        ):
+
             def build_timer(delay, fn):
                 timer = MagicMock()
                 timer.delay = delay

--- a/tests/test_history_store.py
+++ b/tests/test_history_store.py
@@ -117,17 +117,36 @@ def test_autosave_does_not_break_manual_history(tmp_path):
     assert autosave_loaded["system_prompt"] == "autosave sys"
 
 
-def test_manual_history_reserved_name_rejected(tmp_path):
+def test_manual_history_reserved_name_rejected_for_save(tmp_path):
     store = HistoryStore(base_dir=tmp_path)
 
-    with pytest.raises(ValueError):
-        store.history_exists("user-1", "_autosave")
+    assert store.history_exists("user-1", "_autosave") is False
 
     with pytest.raises(ValueError):
         store.save_history("user-1", "_autosave", system_prompt="", turns=[])
 
-    with pytest.raises(ValueError):
+    with pytest.raises(FileNotFoundError):
         store.load_history("user-1", "_autosave")
+
+
+def test_load_history_supports_legacy_reserved_filename(tmp_path):
+    store = HistoryStore(base_dir=tmp_path)
+    user_dir = tmp_path / "user-1"
+    user_dir.mkdir(parents=True, exist_ok=True)
+
+    legacy_payload = {
+        "display_name": "_autosave",
+        "system_prompt": "legacy",
+        "turns": [{"role": "user", "content": "hello"}],
+        "metadata": {"schema_version": 1},
+    }
+    (user_dir / "_autosave.json").write_text(
+        json.dumps(legacy_payload, ensure_ascii=False, indent=2)
+    )
+
+    loaded = store.load_history("user-1", "_autosave")
+    assert loaded["display_name"] == "_autosave"
+    assert loaded["system_prompt"] == "legacy"
 
 
 def test_load_autosave_invalid_json_shape_ignored(tmp_path):

--- a/tests/test_history_store.py
+++ b/tests/test_history_store.py
@@ -129,6 +129,15 @@ def test_manual_history_reserved_name_rejected_for_save(tmp_path):
         store.load_history("user-1", "_autosave")
 
 
+def test_history_exists_returns_true_even_for_invalid_json_file(tmp_path):
+    store = HistoryStore(base_dir=tmp_path)
+    user_dir = tmp_path / "user-1"
+    user_dir.mkdir(parents=True, exist_ok=True)
+    (user_dir / "Broken.json").write_text("{invalid json")
+
+    assert store.history_exists("user-1", "Broken") is True
+
+
 def test_load_history_supports_legacy_reserved_filename(tmp_path):
     store = HistoryStore(base_dir=tmp_path)
     user_dir = tmp_path / "user-1"


### PR DESCRIPTION
## 概要
- Issue #149 の要件に沿って autosave トリガーを実装
- ユーザー発話反映後 / LLM応答確定後 / システムプロンプト更新後に autosave を要求
- 最短間隔デバウンス（既定2秒）を ChatService に実装
- CLI 終了時の flush_autosave と WebUI サービス差し替え時の pending cancel を追加
- autosave 予約名・互換読み込み・一覧除外を HistoryStore で整備

## 変更ファイル
- src/multi_llm_chat/chat_service.py
- src/multi_llm_chat/cli.py
- src/multi_llm_chat/history.py
- src/multi_llm_chat/webui/app.py
- src/multi_llm_chat/webui/handlers.py
- tests/test_chat_service.py
- tests/test_cli.py
- tests/test_history_store.py
- tests/test_webui.py
- tests/test_webui_app.py

## 追加/更新テスト（TDD）
- test_autosave_updates_on_user_message
- test_autosave_updates_on_assistant_finalize
- test_autosave_debounce
- test_configure_autosave_cancels_previous_pending_task
- test_request_autosave_debounces_with_thread_timer_without_running_loop
- test_request_autosave_cancels_pending_before_immediate_save
- test_flush_autosave_saves_pending_state_immediately
- test_system_command_update_triggers_autosave
- test_cli_flush_autosave_uses_latest_state_after_reset
- test_manual_history_reserved_name_rejected_for_save
- test_load_history_supports_legacy_reserved_filename
- test_respond_replaces_service_after_cancelling_old_autosave
- test_update_ui_on_prompt_change_triggers_autosave

## 動作確認
- uv run ruff check src/multi_llm_chat/chat_service.py src/multi_llm_chat/history.py src/multi_llm_chat/cli.py src/multi_llm_chat/webui/handlers.py tests/test_chat_service.py tests/test_history_store.py tests/test_cli.py tests/test_webui.py tests/test_webui_app.py
- uv run pytest -q tests/test_chat_service.py -k autosave
- uv run pytest -q tests/test_history_store.py -k "autosave or reserved"
- uv run pytest -q tests/test_cli.py -k "system_command_update_triggers_autosave or flush_autosave_uses_latest_state_after_reset"
- uv run pytest -q tests/test_webui.py -k "replaces_service_after_cancelling_old_autosave or system_prompt_included_in_chat"
- uv run pytest -q tests/test_webui_app.py -k prompt_change_triggers_autosave

Closes #149
